### PR TITLE
RHMAP-16201 Update travis node version for Appforms-Template-v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4.4.3"
+  - "6.9.1"
 sudo: false
 before_install:
-  - npm install -g npm@2.13.5
   - npm install -g grunt-cli
-install: npm install
+install:
+  - npm install

--- a/README.md
+++ b/README.md
@@ -77,5 +77,5 @@ This client app already has the correct structure to be imported directly into t
 ### Updating fh-js-sdk version
 To update the JS SDK:
 - change the version in [package.json](package.json)
-- run `npm install` a grunt task is automatically ran to regenerate `www/browserify.js`
-- check-in git repo the new package.json + `www/browserify.js`
+- run `npm install` a grunt task is automatically ran to regenerate `www/lib/browserify.js`
+- check-in git repo the new package.json + `www/lib/browserify.js`


### PR DESCRIPTION
Updated node versions for travis to
- "4.4.3"
- "6.9.1"

Removed npm installation as node 4 and node 6 bring a more updated npm

Small fix on the README.md
