### PR TITLE
task(CVE-2017-18214): RHMAP-20717: Upgrade moment dep

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+1.3.18 - 2018-06-12 -
+Updating moment to 2.22.2
+
 1.3.16 - 2017-10-23 - Rachael O'Regan
 
 Updating fh-js-sdk to 2.22.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FeedHenry-App-Forms-Phase3-App-Generator",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "dependencies": {
     "async": "~2.1.5",
     "backbone": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "fastclick": "1.0.6",
     "fh-js-sdk": "2.23.1",
     "jquery": "3.1.0",
-    "moment": "2.14.1",
+    "moment": "2.22.2",
     "underscore": "1.8.3"
   },
   "scripts": {


### PR DESCRIPTION
## JIRA
https://issues.jboss.org/browse/RHMAP-20717

## WHAT
- Upgrade moment dependency from 2.14.1 to 2.22.2 

## WHY
Solve vulnerability. For further information check: https://nvd.nist.gov/vuln/detail/CVE-2017-18214

## USAGE
Used to manipulate dates (https://github.com/feedhenry/Appforms-Template-v3/search?q=moment&unscoped_q=moment)
PS.: It is not a break change/update. See the moment [Changelog](https://github.com/moment/moment/blob/develop/CHANGELOG.md)

## TEST
Run grunt tasks 

````
cmacedo@camilas-MBP ~/fh-templates/Appforms-Template-v3 (RHMAP-20717) $ grunt
Running "clean" task
did not delete dist.zip
did not delete max.zip

Running "jshint:files" (jshint) task
>> 24 files lint free.

Running "mochaTest:test" (mochaTest) task


  Router
    ✓ Resuming Should Fetch Forms When Enabled
    ✓ Resuming Should Not Fetch Forms When Not Enabled


  2 passing (9ms)


Running "browserify:www/lib/browserify.js" (browserify) task
>> Bundle www/lib/browserify.js created.

Running "mkdirs" task
dist dirs created

Running "concat:dist" (concat) task
File "dist-dev/www/main.js" created.

Running "concat:lib" (concat) task
File "./dist-dev/www/lib.js" created.

Running "copy:dist" (copy) task
Created 7 directories, copied 61 files

Running "uglify:lib" (uglify) task
File ./dist/www/lib.min.js created.

Running "index" task
index copied and modified

Done, without errors.


Execution Time (2018-06-12 10:42:12 UTC)
jshint:files                      408ms  ▇▇▇ 3%
browserify:www/lib/browserify.js   2.6s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 19%
uglify:lib                        10.2s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 76%
Total 13.5s
cmacedo@camilas-MBP ~/fh-templates/Appforms-Template-v3 (RHMAP-20717) $ 
````
